### PR TITLE
chore: disallow indexing of CV page

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /cv/


### PR DESCRIPTION
## Summary
- add robots.txt to block indexing of /cv/

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68c006ba0c2c832692ba26b10ae6fdc2