### PR TITLE
Add blog post on Avion Level D FFS

### DIFF
--- a/_posts/2025-09-10-avion-level-d-ffs.md
+++ b/_posts/2025-09-10-avion-level-d-ffs.md
@@ -1,0 +1,23 @@
+---
+title: "Avion Level D FFS and Their Future Importance"
+date: 2025-09-10
+permalink: /posts/2025/09/avion-level-d-ffs/
+tags:
+  - aviation
+  - simulation
+  - training
+---
+
+Level D full flight simulators (FFS) represent the highest standard of flight training devices, capable of replicating every nuance of modern aircraft. At [Avion](https://www.aviongroup.aero), I had the opportunity to work on the development of a Level D FFS project for about two years, helping bring cockpit dynamics, flight models, and instructor tools into perfect alignment with real‑world operations.
+
+These simulators are becoming increasingly important as airlines adopt more advanced aircraft and seek cost‑effective, environmentally friendly training solutions. They allow pilots to rehearse complex scenarios without leaving the ground, reducing the need for costly fuel and maintenance associated with real aircraft training.
+
+Manufacturers continue to push the fidelity of Level D devices to match the capabilities of flagship aircraft from [Airbus](https://www.airbus.com) and [Boeing](https://www.boeing.com). As future fleets integrate more automation and alternative propulsion systems, next‑generation simulators will be essential for safe transitions and ongoing proficiency.
+
+Looking ahead, Level D FFS technology will play a central role in preparing crews for future cockpits, supporting mixed‑reality training environments, and enabling global standards for competency‑based pilot instruction. The work we accomplished at Avion lays the groundwork for these advancements, underscoring how vital these simulators will remain in the decades to come.
+
+## References
+- [Avion Group](https://www.aviongroup.aero)
+- [Airbus](https://www.airbus.com)
+- [Boeing](https://www.boeing.com)
+


### PR DESCRIPTION
## Summary
- Add blog post detailing Avion Level D full flight simulators and their future significance.
- Mention personal two-year involvement and provide references to Avion, Airbus, and Boeing.

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68c00cf752588326ab601c2151901241