### PR TITLE
Expand model watermarking blog with citations

### DIFF
--- a/_posts/2025-10-15-model-watermarking-future.md
+++ b/_posts/2025-10-15-model-watermarking-future.md
@@ -1,0 +1,37 @@
+---
+title: "Model Watermarking and the Future of Trustworthy AI"
+date: 2025-10-15
+permalink: /posts/2025/10/model-watermarking-future/
+tags:
+  - model-watermarking
+  - security
+  - machine-learning
+---
+
+Model watermarking embeds identifiable patterns into a model’s parameters or outputs so that ownership can be demonstrated without access to the original training process. Early work showed that weights of deep networks can carry hidden signatures without affecting accuracy [3]. Subsequent methods trained models on trigger sets to create behavior-based marks resilient to fine‑tuning [4,5].
+
+### Toward resilient Proof-of-Learning
+
+Our research investigates how watermarking strengthens Proof-of-Learning (PoL) by binding models to verifiable training artifacts. Feature-based schemes tie a model’s internal representations to secret keys, making spoofing attacks detectable [1]. A follow‑up evaluation compared parameter, data, and feature watermarking across robustness metrics, highlighting trade-offs between security and computational cost [2].
+
+### Emerging applications and challenges
+
+Watermarking is moving from academic prototypes to industry as open model sharing proliferates. Regulations that demand auditable ML pipelines will rely on provenance techniques to certify that models were trained ethically. Meanwhile, attackers explore watermark removal and collusion strategies, prompting defenses that combine robust statistics with cryptographic attestations [3,5].
+
+### Future importance
+
+In the coming years watermarking will enable:
+
+1. traceable model marketplaces where ownership claims are verifiable,
+2. protection against model theft in collaborative research and AI-as-a-service,
+3. standardized PoL pipelines for decentralized training networks.
+
+Watermarks that survive pruning, quantization, and transfer learning will be essential to these deployments.
+
+## References
+
+[1] Ural, O. and Yoshigoe, K. (2024). *Enhancing Security of Proof-of-Learning against Spoofing Attacks using Feature-Based Model Watermarking*. IEEE Access.
+[2] Ural, O. and Yoshigoe, K. (2025). *Evaluation of Model Watermarking Techniques for Proof-of-Learning Security Against Spoofing Attacks*. IEEE Access (in press).
+[3] Uchida, Y., Nagai, Y., Sakazawa, S., & Satoh, S. (2017). *Embedding Watermarks into Deep Neural Networks*. ICMR.
+[4] Adi, Y., Baum, C., Cisse, M., Pinkas, B., & Keshet, J. (2018). *Turning Your Weakness Into a Strength: Watermarking Deep Neural Networks by Backdooring*. USENIX Security.
+[5] Rouhani, B. D., Chen, H., & Koushanfar, F. (2019). *DeepSigns: A Generic Watermarking Framework for IP Protection of Deep Learning Models*. arXiv:1804.00750.


### PR DESCRIPTION
## Summary
- broaden model watermarking blog post with state-of-the-art background
- cite our IEEE Access articles and foundational watermarking papers

## Testing
- `bundle exec jekyll build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c00c70be8c83269de2d365aec12908