### PR TITLE
Add life blog section with first post

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,3 +16,5 @@ main:
     url: /projects/
   - title: "Technical Blog"
     url: /blog/
+  - title: "Life Blog"
+    url: /life/

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -12,6 +12,6 @@ redirect_from:
 Here you can find deep dives into various technical topics. Click on a post title to read more.
 
 {% include base_path %}
-{% for post in site.posts %}
+{% for post in site.categories.technical %}
   {% include archive-single.html %}
 {% endfor %}

--- a/_pages/life.md
+++ b/_pages/life.md
@@ -1,0 +1,13 @@
+---
+permalink: /life/
+title: "Life Blog"
+author_profile: true
+layout: archive
+---
+
+Thoughts and experiences about life abroad, culture, and personal growth.
+
+{% include base_path %}
+{% for post in site.categories.life %}
+  {% include archive-single.html %}
+{% endfor %}

--- a/_posts/2024-06-09-usa-vs-nl-expat.md
+++ b/_posts/2024-06-09-usa-vs-nl-expat.md
@@ -1,0 +1,26 @@
+---
+title: "USA vs Netherlands: An Expat's Perspective"
+date: 2024-06-09
+permalink: /posts/2024/06/usa-vs-nl-expat/
+categories: life
+tags:
+  - expat
+  - culture
+  - comparison
+---
+
+Living as an expat has given me the chance to compare daily life in the United States and the Netherlands.
+
+## Work–Life Balance
+
+Dutch workplaces generally emphasize balance, with shorter workweeks and more vacation time. In the U.S., longer hours are common, but there is often greater flexibility to change careers or move between cities.
+
+## Transportation
+
+Public transit and cycling rule in the Netherlands, making commutes predictable and healthy. In contrast, many U.S. cities are car-centric, which offers freedom but also brings traffic and parking challenges.
+
+## Community
+
+The Dutch tend to separate work and private life, keeping social circles small but loyal. Americans are often open to casual conversation and quick friendships, even if they remain surface-level.
+
+These differences shape daily experiences and highlight the unique strengths of each culture.

--- a/_posts/2025-09-09-autonomous-drones-future.md
+++ b/_posts/2025-09-09-autonomous-drones-future.md
@@ -2,6 +2,7 @@
 title: "Autonomous Drones and Their Future Importance"
 date: 2025-09-09
 permalink: /posts/2025/09/autonomous-drones-future/
+categories: technical
 tags:
   - drones
   - autonomy

--- a/_posts/2025-09-09-avion-level-d-ffs.md
+++ b/_posts/2025-09-09-avion-level-d-ffs.md
@@ -2,6 +2,7 @@
 title: "Avion Level D FFS and Their Future Importance"
 date: 2025-09-09
 permalink: /posts/2025/09/avion-level-d-ffs/
+categories: technical
 tags:
   - aviation
   - simulation

--- a/_posts/2025-09-09-blockchain-enhanced-ml.md
+++ b/_posts/2025-09-09-blockchain-enhanced-ml.md
@@ -2,6 +2,7 @@
 title: "Blockchain-Enhanced Machine Learning: Linking Trust, Data, and Incentives"
 date: 2025-09-09
 permalink: /posts/2025/09/blockchain-enhanced-ml/
+categories: technical
 tags:
   - blockchain
   - machine-learning

--- a/_posts/2025-09-09-ml-enhanced-blockchain.md
+++ b/_posts/2025-09-09-ml-enhanced-blockchain.md
@@ -2,6 +2,7 @@
 title: "ML-Enhanced Blockchain: Toward Intelligent, Adaptive Ledgers"
 date: 2025-09-09
 permalink: /posts/2025/09/ml-enhanced-blockchain/
+categories: technical
 tags:
   - blockchain
   - machine-learning

--- a/_posts/2025-09-09-model-watermarking-future.md
+++ b/_posts/2025-09-09-model-watermarking-future.md
@@ -2,6 +2,7 @@
 title: "Model Watermarking and the Future of Trustworthy AI"
 date: 2025-09-09
 permalink: /posts/2025/09/model-watermarking-future/
+categories: technical
 tags:
   - model-watermarking
   - security

--- a/_posts/2025-09-09-proof-of-learning-future.md
+++ b/_posts/2025-09-09-proof-of-learning-future.md
@@ -2,6 +2,7 @@
 title: "Proof of Learning: Building Trust in Future Machine Learning"
 date: 2025-09-09
 permalink: /posts/2025/09/proof-of-learning-future/
+categories: technical
 tags:
   - proof-of-learning
   - security


### PR DESCRIPTION
## Summary
- Create dedicated Life Blog page and sample expat comparison post
- Filter Technical Blog to technical posts and categorize existing posts
- Add Life Blog to navigation for easy access

## Testing
- `bundle exec jekyll build`
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_68c01a1b8c788326a45b9705c9d12dc9