### PR TITLE
Fix blog post categories for life content

### DIFF
--- a/_posts/2025-09-09-phd-era-florida-ml-security.md
+++ b/_posts/2025-09-09-phd-era-florida-ml-security.md
@@ -2,7 +2,7 @@
 title: "PhD Life at Embry-Riddle: Machine Learning, Security, and Sunshine"
 date: 2025-09-09
 permalink: /posts/2025/09/phd-era-florida-ml-security/
-categories: reflections
+categories: life
 tags:
   - phd
   - machine-learning

--- a/_posts/2025-09-16-slowing-down-time.md
+++ b/_posts/2025-09-16-slowing-down-time.md
@@ -2,7 +2,7 @@
 title: "Slowing Down Time Through Novel Experiences"
 date: 2025-09-16
 permalink: /posts/2025/09/slowing-time-novelty/
-categories: neuroscience
+categories: life
 tags:
   - time-perception
   - memory


### PR DESCRIPTION
## Summary
- Reclassify "PhD Life at Embry-Riddle" post under the `life` category
- Reclassify "Slowing Down Time Through Novel Experiences" as `life`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68c033268b04832694d313322e816e4f