### PR TITLE
Add local like and comment interactions for posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,7 +96,7 @@ future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
 talkmap_link             : false      #change to true to add link to talkmap on talks page
 comments:
-  provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
+  provider               : custom # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:
     shortname            :
   discourse:

--- a/_includes/comments-providers/custom.html
+++ b/_includes/comments-providers/custom.html
@@ -1,3 +1,20 @@
 <!-- start custom comments snippet -->
-
+{% assign interaction_id = page.id | default: page.url | slugify %}
+<div class="local-comments" data-post-id="{{ interaction_id }}">
+  <h4 class="page__comments-title">{{ comments_label }}</h4>
+  <div class="local-comments__list" data-comment-list data-empty-label="{{ site.data.ui-text[site.locale].comment_empty_label | default: 'No comments yet. Be the first to share your thoughts.' }}" aria-live="polite"></div>
+  <form class="local-comments__form" data-comment-form novalidate>
+    <div class="local-comments__field">
+      <label class="local-comments__label" for="comment-name-{{ interaction_id }}">{{ site.data.ui-text[site.locale].comment_form_name_label | default: "Name" }}</label>
+      <input class="local-comments__input" id="comment-name-{{ interaction_id }}" name="comment-name" type="text" data-comment-name autocomplete="name" required />
+    </div>
+    <div class="local-comments__field">
+      <label class="local-comments__label" for="comment-message-{{ interaction_id }}">{{ site.data.ui-text[site.locale].comment_form_comment_label | default: "Comment" }}</label>
+      <textarea class="local-comments__input local-comments__input--textarea" id="comment-message-{{ interaction_id }}" name="comment-message" rows="4" data-comment-message required></textarea>
+    </div>
+    <button class="btn local-comments__submit" type="submit">{{ site.data.ui-text[site.locale].comment_btn_submit | default: "Submit Comment" }}</button>
+  </form>
+  <p class="local-comments__status" data-comment-status data-success-message="{{ site.data.ui-text[site.locale].comment_success_message | default: 'Thanks for sharing your thoughts! (Saved locally.)' }}" data-error-storage="{{ site.data.ui-text[site.locale].comment_storage_error | default: 'We could not save your comment. Check your browser storage settings and try again.' }}" data-error-validation="{{ site.data.ui-text[site.locale].comment_validation_error | default: 'Please enter your name and a comment.' }}" data-storage-disabled="{{ site.data.ui-text[site.locale].comment_storage_disabled | default: 'Local browser storage is disabled, so comments are unavailable.' }}" role="status" aria-live="polite"></p>
+  <p class="local-comments__note">{{ site.data.ui-text[site.locale].comment_storage_note | default: "Comments are saved in your browser and are not shared with the site owner." }}</p>
+</div>
 <!-- end custom comments snippet -->

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,7 @@
 <script type="module" src="{{ base_path }}/assets/js/main.min.js"></script>
 
+{% if page.collection == 'posts' %}
+<script type="module" src="{{ base_path }}/assets/js/post-interactions.js"></script>
+{% endif %}
+
 {% include analytics.html %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -74,6 +74,16 @@ layout: default
         {% endif %}
 
         {% if page.link %}<div><a href="{{ page.link }}" class="btn">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
+
+        {% if page.collection == 'posts' %}
+          <div class="post-interactions" data-post-id="{{ page.id | default: page.url | slugify }}">
+            <button class="post-interactions__like" type="button" data-like-button aria-pressed="false">
+              <span class="post-interactions__like-icon" aria-hidden="true">❤️</span>
+              <span data-like-label data-liked-label="{{ site.data.ui-text[site.locale].liked_label | default: 'Liked' }}">{{ site.data.ui-text[site.locale].like_label | default: "Like" }}</span>
+            </button>
+            <p class="post-interactions__status" data-like-status data-liked-message="{{ site.data.ui-text[site.locale].like_thanks_note | default: 'Thanks for liking this post! (Saved locally.)' }}" data-storage-disabled="{{ site.data.ui-text[site.locale].like_disabled_note | default: 'Local browser storage is disabled, so likes are unavailable.' }}" data-error-storage="{{ site.data.ui-text[site.locale].like_storage_error | default: 'We could not save your like. Please check your browser settings and try again.' }}" role="status" aria-live="polite">{{ site.data.ui-text[site.locale].like_storage_note | default: "Likes are saved locally in this browser." }}</p>
+          </div>
+        {% endif %}
       </section>
 
       <footer class="page__meta">

--- a/_sass/layout/_post-interactions.scss
+++ b/_sass/layout/_post-interactions.scss
@@ -1,0 +1,137 @@
+.post-interactions {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--global-border-color);
+  border-radius: $border-radius;
+  background-color: var(--global-footer-bg-color);
+}
+
+.post-interactions__like {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  color: var(--global-text-color);
+  background-color: transparent;
+  border: 1px solid var(--global-border-color);
+  border-radius: $border-radius;
+  cursor: pointer;
+  transition: $global-transition;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--global-link-color);
+    border-color: var(--global-link-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--global-link-color);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  &:disabled:hover,
+  &:disabled:focus-visible {
+    color: var(--global-text-color);
+    border-color: var(--global-border-color);
+    outline: none;
+  }
+}
+
+.post-interactions__like--active {
+  color: #fff;
+  background-color: var(--global-link-color);
+  border-color: var(--global-link-color);
+
+  &:hover,
+  &:focus-visible {
+    color: #fff;
+  }
+}
+
+.post-interactions__like-icon {
+  font-size: 1.2em;
+}
+
+.post-interactions__status {
+  margin: 0.75rem 0 0;
+  font-size: $type-size-7;
+  color: var(--global-text-color-light);
+}
+
+.local-comments {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--global-border-color);
+  border-radius: $border-radius;
+  background-color: var(--global-footer-bg-color);
+}
+
+.local-comments__list {
+  display: grid;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.local-comments__item {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--global-border-color);
+  border-radius: $border-radius;
+  background-color: var(--global-bg-color);
+}
+
+.local-comments__item-meta {
+  margin: 0 0 0.5rem;
+  font-size: $type-size-7;
+  font-weight: 600;
+  color: var(--global-text-color-light);
+}
+
+.local-comments__item-body {
+  margin: 0;
+  white-space: normal;
+}
+
+.local-comments__empty {
+  margin: 0;
+  font-size: $type-size-7;
+  color: var(--global-text-color-light);
+}
+
+.local-comments__form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.local-comments__input--textarea {
+  min-height: 6rem;
+}
+
+.local-comments__status {
+  margin: 1rem 0 0;
+  font-size: $type-size-7;
+}
+
+.local-comments__status--error {
+  color: $danger-color;
+}
+
+.local-comments__status--success {
+  color: $success-color;
+}
+
+.local-comments__note {
+  margin: 0.5rem 0 0;
+  font-size: $type-size-7;
+  color: var(--global-text-color-light);
+}
+
+.local-comments__submit {
+  justify-self: flex-start;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -35,6 +35,7 @@
     "layout/page",
     "layout/archive",
     "layout/sidebar",
+    "layout/post-interactions",
 
     "vendor/font-awesome/fontawesome",
     "vendor/font-awesome/solid",

--- a/assets/js/post-interactions.js
+++ b/assets/js/post-interactions.js
@@ -1,0 +1,281 @@
+const LIKE_KEY_PREFIX = 'post-like:';
+const COMMENT_KEY_PREFIX = 'post-comments:';
+
+const isStorageAvailable = (() => {
+  try {
+    if (typeof window === 'undefined' || !('localStorage' in window)) {
+      return false;
+    }
+
+    const testKey = '__post_interactions__';
+    window.localStorage.setItem(testKey, '1');
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    return false;
+  }
+})();
+
+const onDocumentReady = (callback) => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', callback, { once: true });
+  } else {
+    callback();
+  }
+};
+
+const formatTimestamp = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  try {
+    return date.toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch (error) {
+    return date.toLocaleString();
+  }
+};
+
+const appendTextWithBreaks = (element, text) => {
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      element.appendChild(document.createElement('br'));
+    }
+    element.appendChild(document.createTextNode(line));
+  });
+};
+
+const setStatusMessage = (statusElement, message, type) => {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+
+  const errorClass = 'local-comments__status--error';
+  const successClass = 'local-comments__status--success';
+  statusElement.classList.remove(errorClass, successClass);
+
+  if (type === 'error') {
+    statusElement.classList.add(errorClass);
+  } else if (type === 'success') {
+    statusElement.classList.add(successClass);
+  }
+};
+
+const initLikeButton = (container, postId) => {
+  const likeButton = container.querySelector('[data-like-button]');
+  const likeLabel = likeButton ? likeButton.querySelector('[data-like-label]') : null;
+  const statusElement = container.querySelector('[data-like-status]');
+
+  if (!likeButton || !likeLabel || !statusElement) {
+    return;
+  }
+
+  const defaultLabel = likeLabel.textContent.trim() || 'Like';
+  const likedLabel = likeLabel.dataset.likedLabel || 'Liked';
+  const defaultStatus = statusElement.textContent.trim() || 'Likes are saved locally in this browser.';
+  const likedStatus = statusElement.dataset.likedMessage || 'Thanks for liking this post! (Saved locally.)';
+  const disabledStatus = statusElement.dataset.storageDisabled || 'Local browser storage is disabled, so likes are unavailable.';
+  const errorStatus = statusElement.dataset.errorStorage || 'We could not save your like. Please check your browser settings and try again.';
+
+  if (!isStorageAvailable) {
+    likeButton.disabled = true;
+    likeButton.setAttribute('aria-pressed', 'false');
+    likeButton.classList.remove('post-interactions__like--active');
+    likeLabel.textContent = defaultLabel;
+    statusElement.textContent = disabledStatus;
+    return;
+  }
+
+  const storageKey = `${LIKE_KEY_PREFIX}${postId}`;
+  let liked = false;
+
+  try {
+    liked = window.localStorage.getItem(storageKey) === 'true';
+  } catch (error) {
+    liked = false;
+  }
+
+  const applyState = (isLiked) => {
+    likeButton.setAttribute('aria-pressed', String(isLiked));
+    likeButton.classList.toggle('post-interactions__like--active', isLiked);
+    likeLabel.textContent = isLiked ? likedLabel : defaultLabel;
+    statusElement.textContent = isLiked ? likedStatus : defaultStatus;
+  };
+
+  applyState(liked);
+
+  likeButton.addEventListener('click', () => {
+    const nextState = !liked;
+    applyState(nextState);
+
+    try {
+      window.localStorage.setItem(storageKey, String(nextState));
+      liked = nextState;
+    } catch (error) {
+      applyState(liked);
+      statusElement.textContent = errorStatus;
+    }
+  });
+};
+
+const loadComments = (storageKey) => {
+  if (!isStorageAvailable) {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((entry) => {
+      return entry && typeof entry.name === 'string' && typeof entry.message === 'string';
+    });
+  } catch (error) {
+    return [];
+  }
+};
+
+const saveComments = (storageKey, comments, statusElement) => {
+  if (!isStorageAvailable) {
+    return false;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(comments));
+    return true;
+  } catch (error) {
+    setStatusMessage(statusElement, statusElement?.dataset.errorStorage || 'We could not save your comment. Check your browser storage settings and try again.', 'error');
+    return false;
+  }
+};
+
+const renderComments = (listElement, comments) => {
+  listElement.innerHTML = '';
+
+  if (!comments.length) {
+    const emptyMessage = listElement.dataset.emptyLabel || 'No comments yet. Be the first to share your thoughts.';
+    const emptyElement = document.createElement('p');
+    emptyElement.className = 'local-comments__empty';
+    emptyElement.textContent = emptyMessage;
+    listElement.appendChild(emptyElement);
+    return;
+  }
+
+  comments.forEach((comment) => {
+    const item = document.createElement('article');
+    item.className = 'local-comments__item';
+
+    const meta = document.createElement('p');
+    meta.className = 'local-comments__item-meta';
+    const formattedDate = formatTimestamp(comment.timestamp);
+    meta.textContent = formattedDate ? `${comment.name} • ${formattedDate}` : comment.name;
+    item.appendChild(meta);
+
+    const body = document.createElement('p');
+    body.className = 'local-comments__item-body';
+    appendTextWithBreaks(body, comment.message);
+    item.appendChild(body);
+
+    listElement.appendChild(item);
+  });
+};
+
+const disableForm = (formElement) => {
+  if (!formElement) {
+    return;
+  }
+
+  const fields = formElement.querySelectorAll('input, textarea, button');
+  fields.forEach((field) => {
+    field.disabled = true;
+  });
+};
+
+const initComments = (container, postId) => {
+  const listElement = container.querySelector('[data-comment-list]');
+  const formElement = container.querySelector('[data-comment-form]');
+  const nameInput = container.querySelector('[data-comment-name]');
+  const messageInput = container.querySelector('[data-comment-message]');
+  const statusElement = container.querySelector('[data-comment-status]');
+
+  if (!listElement || !formElement || !nameInput || !messageInput || !statusElement) {
+    return;
+  }
+
+  const storageKey = `${COMMENT_KEY_PREFIX}${postId}`;
+
+  if (!isStorageAvailable) {
+    disableForm(formElement);
+    setStatusMessage(statusElement, statusElement.dataset.storageDisabled || 'Local browser storage is disabled, so comments are unavailable.', 'error');
+    renderComments(listElement, []);
+    return;
+  }
+
+  let comments = loadComments(storageKey);
+  renderComments(listElement, comments);
+
+  formElement.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const name = nameInput.value.trim();
+    const message = messageInput.value.trim();
+
+    if (!name || !message) {
+      setStatusMessage(statusElement, statusElement.dataset.errorValidation || 'Please enter your name and a comment.', 'error');
+      return;
+    }
+
+    const newComment = {
+      name,
+      message,
+      timestamp: new Date().toISOString(),
+    };
+
+    comments = [...comments, newComment];
+
+    if (!saveComments(storageKey, comments, statusElement)) {
+      comments.pop();
+      return;
+    }
+
+    renderComments(listElement, comments);
+    formElement.reset();
+    setStatusMessage(statusElement, statusElement.dataset.successMessage || 'Thanks for sharing your thoughts! (Saved locally.)', 'success');
+  });
+};
+
+onDocumentReady(() => {
+  const likeContainer = document.querySelector('.post-interactions[data-post-id]');
+  const commentsContainer = document.querySelector('.local-comments[data-post-id]');
+
+  const postId = likeContainer?.dataset.postId || commentsContainer?.dataset.postId;
+  if (!postId) {
+    return;
+  }
+
+  if (likeContainer) {
+    initLikeButton(likeContainer, postId);
+  }
+
+  if (commentsContainer) {
+    initComments(commentsContainer, postId);
+  }
+});


### PR DESCRIPTION
## Summary
- enable Jekyll's custom comment provider and render a local comment form on posts
- add a like button with accessible status messaging for each blog post
- implement supporting JavaScript and styles for local-storage backed likes and comments

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c9330210fc8326aa66a487d54768d3