### PR TITLE
Add Twitter profile link to author profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,7 +71,7 @@ author:
   steam            :
   telegram         :
   tumblr           :
-  twitter          : # ozgurural
+  twitter          : "ozgurural"
   vine             :
   weibo            :
   wikipedia        :
@@ -133,7 +133,7 @@ yandex_site_verification :
 
 # Social Sharing
 twitter:
-  username               : &twitter
+  username               : &twitter "ozgurural"
 facebook:
   username               :
   app_id                 :


### PR DESCRIPTION
## Summary
- add the site author's Twitter handle so the homepage shows the link with other profiles
- configure the global Twitter username for metadata sharing tags

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c9334e9b4c8326a9db0940797c0d90