### PR TITLE
Link author location to Google Maps

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -25,7 +25,12 @@
     <ul class="author__urls social-icons">
       <!-- Font Awesome icons / Biographic information  -->
       {% if author.location %}
-        <li class="author__desktop"><i class="fas fa-fw fa-location-dot icon-pad-right" aria-hidden="true"></i>{{ author.location }}</li>
+        {% assign encoded_location = author.location | uri_escape %}
+        <li class="author__desktop">
+          <a href="https://www.google.com/maps/search/?api=1&query={{ encoded_location }}">
+            <i class="fas fa-fw fa-location-dot icon-pad-right" aria-hidden="true"></i>{{ author.location }}
+          </a>
+        </li>
       {% endif %}
       {% if author.employer %}
         {% if author.employer_url %}


### PR DESCRIPTION
## Summary
- link the author location entry in the profile to a Google Maps search for the configured location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c96484331c8326a736fa91067a226f