### PR TITLE
Use drozgurural as contact email

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ author:
   employer         : "Avion Full Flight Simulators"
   employer_url     : "https://www.aviongroup.aero/"
   uri              :
-  email            : "ozgururalnl@gmail.com"
+  email            : "drozgurural@gmail.com"
   # Academic websites
   academia         : # URL
   arxiv            : # URL - Update with the correct link to your profile


### PR DESCRIPTION
## Summary
- update the author email to use only the drozgurural Gmail address for contact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f645d3a0148326842e8f266dceb836